### PR TITLE
changes to support feeds (and other non-html things)

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -437,9 +437,20 @@ export const RenderAllPages = ( content = [], layout = [] ) => {
 						.catch( error => reject( error ) )
 						.then( content => RenderFile( content, filePath.replace( SETTINGS.get().folder.content, '' ) ) )
 						.then( HTML => {
-							const newPath = Path.normalize(`${ SETTINGS.get().folder.site }/${ page === SETTINGS.get().folder.homepage ? '' : page }/index.html`);
 
-							CreateFile( newPath, ParseHTML( SETTINGS.get().site.doctype + HTML ) )
+                            let { doctype, dest } = Pages.get()[page];
+
+                            if( doctype === undefined ) {
+                                doctype = SETTINGS.get().site.doctype;
+                            }
+
+                            if( dest === undefined ) {
+                                dest = ( page === SETTINGS.get().folder.homepage ? '' : page ) + '/index.html';
+                            }
+
+							const newPath = Path.normalize(`${ SETTINGS.get().folder.site }/${dest}`);
+
+							CreateFile( newPath, ParseHTML( doctype + HTML ) )
 								.catch( error => reject( error ) );
 
 							Progress.tick();

--- a/src/render.js
+++ b/src/render.js
@@ -154,7 +154,11 @@ export const RenderReact = ( componentPath, props, source = '' ) => {
 			component = require( componentPath ).default;
 		}
 
-		return ReactDOMServer.renderToStaticMarkup( React.createElement( component, props ) );
+        if ( props.noreact ) {
+            return component(props);
+        }
+
+        return ReactDOMServer.renderToStaticMarkup( React.createElement( component, props ) );
 	}
 	catch( error ) {
 		Log.error(`The react component ${ Style.yellow( componentPath.replace( SETTINGS.get().folder.code, '' ) ) } had trouble rendering:`);


### PR DESCRIPTION
This is more of a RFC than a PR, and was motivated by #16.

The goal is to support the generation of pages that don't follow the generic template (case in point: feed files). There are a few ways to skin that cat, and I gave a go at a way that is pretty generic. 

problem 1: the feed files shouldn't have the <!DOCTYPE> prepended to them.

Solution 1: I added  the possibility to override the global `doctype` on a per-file basis.

problem 2: the rendering of feeds does not need react.

solution 2: actually, I could just have fudged my way by using a component looking like

```
import React, { Fragment } from 'react';

const Rss = entries = > { blah blah blah };

export default ({ entries }) => <Fragment 
  dangerouslySetInnerHTML={ { __html: Rss(entries) } }
/>
```

but that's roundabout a little bit, so I added a `noreact` prop that, if set to true, will make cuttlebelle take the output of the component as-is instead of Reacting it. So the above becomes:

```
import React, { Fragment } from 'react';

const Rss = entries = > { blah blah blah };

export default ({ entries }) => Rss(entries);
```

problem 3: the pages generated by cuttlebelle all end up of the form `$page/index.html`.  But for things like feed, we might want, e.g., `/feed/atom.xml` instead.

solution 3: add a `dest` prop that overrides the default destination location.  (warning: I didn't touch anything having to do with relative links. moving the `dest` probably break those)

*NOTE*: the names that I picked for the props are probably sub-optimal, but they can be easily changed for anything else we may desire.

*WARNING*: the code for watch.js has to be changed as well.