### PR TITLE
Fixed a couple minor bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ Cuttlebelle changelog
 
 ## Release History
 
+### v1.0.0-alpha.64
+
+- When quitting the watch an error would occur siting `SIGINT` which is just the signal to exit the program. We skip that "error" now.
+- When combining `-w` and `-n` flags the watch would not run. It does now.
+
 ### v1.0.0-alpha.63
 
 - Added `getInitialProps` for async data fetching

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "cuttlebelle",
 	"description": "The react static site generator that separates editing and code concerns",
-	"version": "1.0.0-alpha.63",
+	"version": "1.0.0-alpha.64",
 	"homepage": "http://cuttlebelle.com",
 	"author": {
 		"name": "Dominik Wilkowski",

--- a/src/helper.js
+++ b/src/helper.js
@@ -295,7 +295,7 @@ export const Notify = {
  * @param {object} error   - Object to distinguish between closing events
  */
 export const ExitHandler = ( exiting /*: { withoutSpace: boolean } */, error /*: string */ ) => {
-	if( error && parseInt( error ) !== 1 ) {
+	if( error && parseInt( error ) !== 1 && error !== 'SIGINT' ) {
 		try {              // try using our pretty output
 			Log.error( error );
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -171,17 +171,14 @@ else {
 				`to ${ Style.yellow( SETTINGS.get().folder.site.replace( SETTINGS.get().folder.cwd, '' ) ) } ` +
 				`in ${ Style.yellow(`${ ConvertHrtime( elapsedTime ) }s`) }`
 			);
+		}
+		else {
+			Log.info(`Skipping generation of pages`);
+		}
 
-			// run watch on flag
-			if( Watch.running ) {
-				Watch.start();
-			}
-			else {
-				// run watch on flag
-				if( process.argv.includes('-w') || process.argv.includes('watch') ) {
-					Watch.start();
-				}
-			}
+		// run watch on flag
+		if( Watch.running ) {
+			Watch.start();
 		}
 	})();
 }


### PR DESCRIPTION
- When quitting the watch an error would occur siting `SIGINT` which is just the signal to exit the program. We skip that "error" now
- When combining `-w` and `-n` flags the watch would not run. It does now 